### PR TITLE
use less compiler flags in gpsp makefile

### DIFF
--- a/patches/gpsp-patch-makefile.patch
+++ b/patches/gpsp-patch-makefile.patch
@@ -8,15 +8,13 @@ index f043a85..5ddf848 100644
  
 +# Go-Advance
 +else ifeq ($(platform), goadvance)
-+	CPUFLAGS := -Ofast -marm -march=armv8-a+crc+simd -mtune=cortex-a35 -mcpu=cortex-a35 -mfpu=neon-fp-armv8 -mfloat-abi=hard -flto -DUSE_RENDER_THREAD -DNO_ASM -DARM_ASM -frename-registers -ftree-vectorize
-+	CFLAGS   := -DNDEBUG -Ofast -fno-ident
-+	LDFLAGS  += -Ofast -fno-ident
-+	CFLAGS  += $(CPUFLAGS) -fpic -fomit-frame-pointer -ffast-math -fno-rtti -fno-exceptions -fno-non-call-exceptions -Wno-psabi -Wno-format
-+	LDFLAGS += $(CPUFLAGS) -lpthread -Wl,--gc-sections -shared
++	CPUFLAGS := -marm -march=armv8-a+crc+simd -mtune=cortex-a35 -mcpu=cortex-a35 -mfpu=neon-fp-armv8 -mfloat-abi=hard -flto
++	CFLAGS  := $(CPUFLAGS) -fpic -ffast-math -fno-rtti -fno-exceptions
 +	TARGET := $(TARGET_NAME)_libretro.so
 +	fpic := -fPIC
 +	SHARED := -shared -Wl,--version-script=link.T -Wl,--no-undefined
 +	CPU_ARCH := arm
++ MMAP_JIT_CACHE = 1
 +	HAVE_DYNAREC = 1
 +
  # Raspberry Pi 3


### PR DESCRIPTION
i had not tested these compiler flags enough and found that some of them were causing random crashes in games like ff6. this should prevent them with minimal performance difference. it also adds the MMAP_JIT_CACHE flag that was added to the raspberry pi flags in the latest commits