### PR TITLE
Fix incorrect working directory

### DIFF
--- a/builds.sh
+++ b/builds.sh
@@ -125,6 +125,7 @@ do
        var=all
        for build_this in scripts/*.sh
        do
+           cd $cur_wd
            bittest=$(head -20 $build_this | grep -i '"$bitness" == ' | tr -dc '0-9')
            bitresult=${bittest: -2}
            if [[ $build_this == *"mame"* ]] || [[ $build_this == *"mess"* ]]; then
@@ -134,7 +135,6 @@ do
            elif [[ ! -z $bitresult ]] && [[ $bitresult != $bitness ]]; then
              echo "Skipping $build_this as it's not to be built in this current ${bitness}bit environment"
            else
-                cd $cur_wd
                 source $build_this
                 if [[ $? != "0" ]]; then
                      echo " "


### PR DESCRIPTION
When building all cores the working directory gets changed in every script for every core, this causes that after 1 iteration in the for loop the working dir is no longer in `~/rk3326_core_builds`.

This causes that the `head` command fails inside this expression:
```
bittest=$(head -20 $build_this | grep -i '"$bitness" == ' | tr -dc '0-9')
```

The solution is to reset the working dir after each iteration.

