### PR TITLE
Adding docker container to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This script was designed to work with 32bit and 64bit chroot Linux environments for the RK3326 chipset. \
 See [this document](https://github.com/christianhaitian/rk3326_core_builds/blob/main/docs/chroot.md) for instructions on how to create them yourself. \
 You can also download a prebuilt one I created by following the information [here](https://forum.odroid.com/viewtopic.php?p=306185#p306185) \
-Or you can use a [Docker container](https://github.com/cscribn/rk-core-builder) contributed by [cscribn](https://github.com/cscribn).
+Or you can use a [Docker container](https://github.com/cscribn/rk-core-builder) contributed by [Chad Scribner](https://github.com/cscribn).
 
 This script is designed to only build cores, retroarch and PPSSPP that are compatible with the aarch64 or armhf environment it's run from.  So to build cores for the 32bit armhf environment, it should be run from an arm32 environment such as a 32bit chroot.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
 ### Assumptions:
 This script was designed to work with 32bit and 64bit chroot Linux environments for the RK3326 chipset. \
 See [this document](https://github.com/christianhaitian/rk3326_core_builds/blob/main/docs/chroot.md) for instructions on how to create them yourself. \
-You can also download a prebuilt one I created by following the information [here](https://forum.odroid.com/viewtopic.php?p=306185#p306185)
+You can also download a prebuilt one I created by following the information [here](https://forum.odroid.com/viewtopic.php?p=306185#p306185) \
+Or you can use a [Docker container](https://github.com/cscribn/rk-core-builder) contributed by [cscribn](https://github.com/cscribn).
 
 This script is designed to only build cores, retroarch and PPSSPP that are compatible with the aarch64 or armhf environment it's run from.  So to build cores for the 32bit armhf environment, it should be run from an arm32 environment such as a 32bit chroot.
 


### PR DESCRIPTION
I created and tested a Docker container for the rk core builds. The purpose of this pull request is to update the README with a link to the GitHub repo.