### PR TITLE
Specify the most recent Amiberry compatible with patches/amiberrysa-patch-platform.patch

### DIFF
--- a/scripts/amiberry.sh
+++ b/scripts/amiberry.sh
@@ -11,14 +11,15 @@
 
 cur_wd="$PWD"
 bitness="$(getconf LONG_BIT)"
+TAG="v5.6.8"
 
 	# amiberry package
 	if [[ "$var" == "amiberry" ]] && [[ "$bitness" == "64" ]]; then
 	 cd $cur_wd
-     git clone --recursive https://github.com/BlitterStudio/amiberry.git
+         git clone --recursive https://github.com/BlitterStudio/amiberry.git -b ${TAG}
 	 if [[ $? != "0" ]]; then
 	   echo " "
-	   echo "There was an error while cloning the mgba standalone git.  Is Internet active or did the git location change?  Stopping here."
+	   echo "There was an error while cloning the amiberry standalone git.  Is Internet active or did the git location change?  Stopping here."
 	   exit 1
 	 fi
 


### PR DESCRIPTION
Follows the pattern of other build scripts in this repo by specifying the tag to use when it clones the Amiberry repo. Specifically, `v5.6.8`. Having checked `patches/amiberrysa-patch-platform.patch` against Amiberry versions, 5.6.8 is the most recent version compatible with the patch.

I have confirmed that the script successfully builds Amiberry version 5.6.8 and that it runs on an RK3326 device (BATLEXP G350).